### PR TITLE
Add config option to also target secondary link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to the Modify Contact Admin Button project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.1.1] - 2022-03-07
-### Changed
-- PHP8 compatibility fixes (GR)
-
 ## [2.1.0] - 2020-02-24
 ### Changed
 - Remove old authors from config.json and update description (Philip Chase)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Modify Contact Admin Button project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.1] - 2022-02-21
+### Changed
+- PHP8 compatibility fix (GR)
+
 ## [2.1.0] - 2020-02-24
 ### Changed
 - Remove old authors from config.json and update description (Philip Chase)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,9 @@
 All notable changes to the Modify Contact Admin Button project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.1.2] - 2022-03-07
+## [2.1.1] - 2022-03-07
 ### Changed
-- More PHP8 compatibility fixes (GR)
-
-## [2.1.1] - 2022-02-21
-### Changed
-- PHP8 compatibility fix (GR)
+- PHP8 compatibility fixes (GR)
 
 ## [2.1.0] - 2020-02-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Modify Contact Admin Button project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.2] - 2022-03-07
+### Changed
+- More PHP8 compatibility fixes (GR)
+
 ## [2.1.1] - 2022-02-21
 ### Changed
 - PHP8 compatibility fix (GR)

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -15,7 +15,7 @@ class ExternalModule extends AbstractExternalModule {
 
     function redcap_module_configure_button_display($project_id = null) {
         // Only super users may configure on the project level.
-        return SUPER_USER == 1 ? true : null;
+        return defined("SUPER_USER") && SUPER_USER == 1 ? true : null;
     }
 
     /**
@@ -57,7 +57,7 @@ class ExternalModule extends AbstractExternalModule {
                     "user_lastname" => $user_lastname,
                     "user_email" => $user_email,
                     "project_id" => $project_id,
-                    "USERID" => USERID,
+                    "USERID" => defined("USERID") ? USERID: "",
             ];
 
             // Build URL.

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -32,6 +32,7 @@ class ExternalModule extends AbstractExternalModule {
             $same_tab = false;
             $remove_suggest_link = $this->getProjectSetting('contact-admin-button-remove-suggest-new-feature-project');
             $hide = $this->getProjectSetting('contact-admin-button-hide-project');
+            $topLink = $this->getProjectSetting('contact-admin-button-modify-toplink');
 
             if($this->getProjectSetting('contact-admin-button-override-project')) {
                 // Use project overrides.
@@ -41,6 +42,7 @@ class ExternalModule extends AbstractExternalModule {
                 $parameter_values = $this->getProjectSetting('contact-admin-button-parameter-value-project');
                 $label = $this->getProjectSetting('contact-admin-button-label-project');
                 $same_tab = $this->getProjectSetting('contact-admin-button-sametab-project');
+                $topLink = $this->getProjectSetting('contact-admin-button-modify-toplink-project');
             }
             if (!strlen($url)) {
                 $url = $this->getSystemSetting('contact-admin-button-url-key');
@@ -75,6 +77,7 @@ class ExternalModule extends AbstractExternalModule {
                 "sameTab" => $same_tab,
                 "hide" => $hide,
                 "removeSuggest" => $remove_suggest_link,
+                "topLink" => $topLink,
             );
             $this->sendVarToJS('contactAdminButtonSettings', $contactAdminButtonSettings);
             $this->includeJs('js/modifyContactAdminButtonURL.js');

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -13,7 +13,7 @@ use ExternalModules\AbstractExternalModule;
  */
 class ExternalModule extends AbstractExternalModule {
 
-    function redcap_module_configure_button_display($project_id) {
+    function redcap_module_configure_button_display($project_id = null) {
         // Only super users may configure on the project level.
         return SUPER_USER == 1 ? true : null;
     }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The `USERID` field contains the redcap username.
 
 Settings on the system-level can be overridden for specific projects by super users only.
 
+Additional Contact REDCap Admininistrator link at the top of project pages (introduced in REDCap v12.3.1) can also be modified with a system-wide setting, which can also be overridden at the project level.
+
 In addition, the label of the 'Contact REDCap administrator' button can be changed, and the button can be removed entirely. Furthermore, the 'Suggest a New Feature' link can be removed for specific projects.
 
 ## Example

--- a/config.json
+++ b/config.json
@@ -35,6 +35,11 @@
             "type": "text"
         },
         {
+            "key": "contact-admin-button-modify-toplink",
+            "name": "Also modify Contact Admin link at top of project page",
+            "type": "checkbox"
+        },
+        {
             "key": "contact-admin-button-descriptive-text",
             "name": "Please make sure you provide both a parameter name and a value.",
             "type": "descriptive"
@@ -80,6 +85,11 @@
         {
             "key": "contact-admin-button-override-project",
             "name": "Override system settings:<br>Check this to override the system settings. When any settings are left blank, the system settings will be used",
+            "type": "checkbox"
+        },
+        {
+            "key": "contact-admin-button-modify-toplink-project",
+            "name": "Also modify Contact Admin link at top of project page",
             "type": "checkbox"
         },
         {

--- a/js/modifyContactAdminButtonURL.js
+++ b/js/modifyContactAdminButtonURL.js
@@ -1,13 +1,15 @@
 $('document').ready(function() {
-    var button = $('#help_panel .btn-contact-admin')
-    if (button.length === 1) {
+    var buttons = [];
+    buttons.push($('#help_panel .btn-contact-admin'));
+    if (contactAdminButtonSettings.topLink) buttons.push($('div.hang:contains("Contact REDCap administrator") a'))
+    for (button of buttons){
         if (contactAdminButtonSettings.url.length > 0) button.attr('href', contactAdminButtonSettings.url)
         if (!contactAdminButtonSettings.sameTab) button.attr('target', '_blank')
         if (contactAdminButtonSettings.label.length > 0) button.html(contactAdminButtonSettings.label)
         if (contactAdminButtonSettings.hide) button.parent().hide()
-    }
-    if (contactAdminButtonSettings.removeSuggest) {
-        let suggestLink = $('#help_panel a[href*="enduser_survey"]')
-        if (suggestLink.length === 1) suggestLink.parent().hide()
+        if (contactAdminButtonSettings.removeSuggest) {
+            let suggestLink = $('#help_panel a[href*="enduser_survey"]')
+            if (suggestLink.length === 1) suggestLink.parent().hide()
+        }
     }
 })

--- a/js/modifyContactAdminButtonURL.js
+++ b/js/modifyContactAdminButtonURL.js
@@ -7,9 +7,9 @@ $('document').ready(function() {
         if (!contactAdminButtonSettings.sameTab) button.attr('target', '_blank')
         if (contactAdminButtonSettings.label.length > 0) button.html(contactAdminButtonSettings.label)
         if (contactAdminButtonSettings.hide) button.parent().hide()
-        if (contactAdminButtonSettings.removeSuggest) {
-            let suggestLink = $('#help_panel a[href*="enduser_survey"]')
-            if (suggestLink.length === 1) suggestLink.parent().hide()
-        }
+    }
+    if (contactAdminButtonSettings.removeSuggest) {
+        let suggestLink = $('#help_panel a[href*="enduser_survey"]')
+        if (suggestLink.length === 1) suggestLink.parent().hide()
     }
 })


### PR DESCRIPTION
As suggested [here](https://community.projectredcap.org/questions/131597/move-of-contact-redcap-administrator-link-to-top-o.html), this PR adds the option to both system-wide settings and project overrides to also modify the secondary Contact REDCap Admin link at the top of the sidebar. The JQuery selector is a real hack, but there is no class or id attribute that can be used in this case.