### PR TITLE
Tests for existing URL query before building new URL

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -63,8 +63,12 @@ class ExternalModule extends AbstractExternalModule {
             // Build URL.
             for($i = 0; $i < $length; $i++){
                 if ($parameter_names[$i] and $parameter_values[$i]){
-                    $url .= '&' . filter_var($parameter_names[$i], FILTER_SANITIZE_URL) . 
-                            '=' . $settings[$parameter_values[$i]];
+                    $query = parse_url($url, PHP_URL_QUERY);
+                    if ($query) {
+                        $url .= '&' . filter_var($parameter_names[$i], FILTER_SANITIZE_URL) . '=' . $settings[$parameter_values[$i]];
+                    } else {
+                        $url .= '?' . filter_var($parameter_names[$i], FILTER_SANITIZE_URL) . '=' . $settings[$parameter_values[$i]];
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR adds a check before building the URL, such that if the base URL contains a query already, then the first parameter is prepended with &, else, that is, if there is no other query string, the parameter is prepended with ?. Maybe you only need to check this for the first parameter, and use & thereafter regardless. But this works according to my testing.

Fixes #14 